### PR TITLE
Replaced git:// protocol with https:// in propEr rebar

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,6 +11,6 @@
 {validate_app_modules, true}.
 {deps, [
     {proper, ".*",
-     {git, "git://github.com/manopapad/proper.git", {branch, "master"}}}
+     {git, "https://github.com/manopapad/proper.git", {branch, "master"}}}
   ]
 }.


### PR DESCRIPTION
Hi there,

git:// fixes the build behind the corporate firewall (assuming https:// can get through)

cheers
Nico
