### PR TITLE
Use unpack_map_jiffy by default

### DIFF
--- a/include/msgpack.hrl
+++ b/include/msgpack.hrl
@@ -82,7 +82,7 @@
 -else.
 -record(options_v3, {
           interface = jiffy :: format_type(),
-          map_unpack_fun = fun msgpack_unpacker:unpack_map/3 ::
+          map_unpack_fun = fun msgpack_unpacker:unpack_map_jiffy/3 ::
                                  msgpack_map_unpacker(),
           impl = erlang      :: erlang | nif,
           allow_atom = none  :: none | pack, %% allows atom when packing

--- a/test/msgpack_test.erl
+++ b/test/msgpack_test.erl
@@ -176,7 +176,20 @@ string_test() ->
     MsgpackStringBin = msgpack:pack(String),
     {ok, String} = msgpack:unpack(MsgpackStringBin).
 
-
+default_test_() ->
+    [
+     {"pack",
+      fun() ->
+              Map = {[{1,2}]},
+              ?assertEqual(pack(Map, [{format, jiffy}]), pack(Map))
+      end},
+     {"unpack",
+      fun() ->
+              Map = {[{1,2}]},
+              Binary = pack(Map, [{format, jiffy}]),
+              ?assertEqual(unpack(Binary, [{format, jiffy}]), unpack(Binary))
+      end}
+    ].
 
 unpack_test_() ->
     [


### PR DESCRIPTION
Now packed by jiffy format, but unpacked by  map format.

``` erl
1> msgpack:unpack(msgpack:pack({[]})).     
{ok,#{}}
```
