### PR TITLE
Fix Dialyzer invalid contract warning

### DIFF
--- a/include/msgpack.hrl
+++ b/include/msgpack.hrl
@@ -32,8 +32,8 @@
                    {msgpack_map(), binary()} | no_return() ).
 
 %% Erlang representation of msgpack data.
--type msgpack_term() :: [msgpack_term()] | msgpack_map_jsx() |
-                        msgpack_map_jiffy() | integer() | float() | binary().
+-type msgpack_term() :: [msgpack_term()] | msgpack_map() |
+                        integer() | float() | binary().
 
 %% @doc ext_packer that packs only tuples with length > 2
 -type msgpack_ext_packer()   :: fun((tuple(), msgpack:options()) ->


### PR DESCRIPTION
The call msgpack:pack(Term::#{},[{'enable_str','true'} | {'format','map'},...])
breaks the contract (msgpack:object(),msgpack:options()) -> binary()