### PR TITLE
Allow packing maps even when {format,map} is not set.

### DIFF
--- a/src/msgpack_packer.erl
+++ b/src/msgpack_packer.erl
@@ -122,7 +122,7 @@ handle_binary(Bin, Opt) ->
     end.
 
 %% %% map interface
-handle_ext(Map, Opt = ?OPTION{interface=map}) when is_map(Map) ->
+handle_ext(Map, Opt) when is_map(Map) ->
     pack_map(maps:to_list(Map), Opt);
 
 handle_ext(Any, _Opt = ?OPTION{ext_packer=Packer,

--- a/test/msgpack_test.erl
+++ b/test/msgpack_test.erl
@@ -237,6 +237,13 @@ map_test_()->
               ?assertEqual(BinaryJSX, Binary)
       end},
 
+     {"pack map without {format,map}",
+      fun() ->
+	      Map = maps:from_list([ {X, X * 2} || X <- lists:seq(0, 16) ]),
+	      Binary = pack(Map),
+	      ?assertEqual({ok,Map}, unpack(Binary, [{format,map}]))
+      end},
+
      {"map length 16",
       fun() ->
               Map = maps:from_list([ {X, X * 2} || X <- lists:seq(0, 16) ]),


### PR DESCRIPTION
Currently, attempting to pack a map without specifying {format,map} will fail:
```
1> msgpack:pack(#{1=>2}).
{error,{badarg,#{1 => 2}}}
```
In my opinion, this is undesirable behavior, since this term can be packed with no ambiguity (Erlang maps should always translate directly to msgpack maps).  It would be nice if the packing operation always succeeded at packing native Erlang maps, since there's no real reason to fail.

I came across an issue recently while working with [erwa](https://github.com/bwegh/erwa), which uses jsx-style maps to represent parts of the [WAMP protocol](http://wamp.ws).  Thus, it sets `{format,jsx}` in its calls to `pack`.  However, if any application data getting packed into the protocol includes native Erlang maps, the serialization will fail, since the overall protocol term to pack will contain both native Erlang maps and jsx-style maps.