### PR TITLE
Allow unpacking str 8 types even when {enable_str,true} is not set.

### DIFF
--- a/src/msgpack_unpacker.erl
+++ b/src/msgpack_unpacker.erl
@@ -86,6 +86,10 @@ unpack_stream(<<16#D9, L:8/big-unsigned-integer-unit:1, V:L/binary, Rest/binary>
               ?OPTION{enable_str=true} = _Opt) ->
     {unpack_string(V), Rest};
 
+unpack_stream(<<16#D9, L:8/big-unsigned-integer-unit:1, V:L/binary, Rest/binary>>,
+              ?OPTION{enable_str=false} = Opt) ->
+    unpack_string_or_raw(V, Opt, Rest);
+
 unpack_stream(<<16#DA, L:16/big-unsigned-integer-unit:1, V:L/binary, Rest/binary>>, Opt) ->
     unpack_string_or_raw(V, Opt, Rest);
 

--- a/test/msgpack_test.erl
+++ b/test/msgpack_test.erl
@@ -176,6 +176,15 @@ string_test() ->
     MsgpackStringBin = msgpack:pack(String),
     {ok, String} = msgpack:unpack(MsgpackStringBin).
 
+string_length_encoding_test() ->
+    %% This test checks proper deserialization of strings that
+    %% have been encoded with all valid length encodings
+    {ok, <<42>>} = msgpack:unpack(<<2#10100001,42>>),
+    {ok, <<42>>} = msgpack:unpack(<<16#D9,1,42>>),
+    {ok, <<42>>} = msgpack:unpack(<<16#DA,0,1,42>>),
+    {ok, <<42>>} = msgpack:unpack(<<16#DB,0,0,0,1,42>>).
+    
+
 default_test_() ->
     [
      {"pack",


### PR DESCRIPTION
Currently, msgpack fails to deserialize strings encoded as [str 8 types](https://github.com/msgpack/msgpack/blob/master/spec.md#formats-str) unless `{enable_str, true}` is set, even though deserializing string types encoded as `fixstr`, `str 16`, and `str 32` works without this option:
```
1> msgpack:unpack(<<2#10100001,1>>).
{ok,<<1>>}
2> msgpack:unpack(<<16#D9,1,1>>).                     
{error,incomplete}
3> msgpack:unpack(<<16#DA,0,1,1>>).
{ok,<<1>>}
4> msgpack:unpack(<<16#DB,0,0,0,1,1>>).
{ok,<<1>>}

5> msgpack:unpack(<<16#D9,1,1>>, [{enable_str,true}]).
{ok,[1]}
```
This pull request fixes case 2 so that it returns a binary string rather than failing, to be consistent with the behavior of cases 1, 3, and 4.