### PR TITLE
Fix msgpack_term() type.

### DIFF
--- a/include/msgpack.hrl
+++ b/include/msgpack.hrl
@@ -33,7 +33,7 @@
 
 %% Erlang representation of msgpack data.
 -type msgpack_term() :: [msgpack_term()] | msgpack_map() |
-                        integer() | float() | binary().
+                        integer() | float() | boolean() | binary().
 
 %% @doc ext_packer that packs only tuples with length > 2
 -type msgpack_ext_packer()   :: fun((tuple(), msgpack:options()) ->


### PR DESCRIPTION
Found this problem when using dialyzer with Erlang/OTP 18.0, using jsx format.