### PR TITLE
Add mix.exs for hex.pm package.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,29 @@
+defmodule Msgpack.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :msgpack,
+     version: "0.3.5",
+     language: :erlang,
+     description: description,
+     package: package,
+     deps: deps]
+  end
+
+  defp deps do
+    []
+  end
+
+  defp description do
+    "MessagePack (de)serializer implementation for Erlang"
+  end
+
+  defp package do
+    [files: ~w(AUTHORS include LICENSE-2.0.txt README.md rebar.config
+               rebar.config.script src test),
+     maintainers: ["UENISHI Kota"],
+     licenses: ["Apache"],
+     links: %{"Website" => "http://msgpack.org/",
+              "GitHub" => "https://github.com/msgpack/msgpack-erlang"}]
+   end
+end


### PR DESCRIPTION
This is related to issue #53.  All that is required is to use `mix hex.publish` when mix/hex is setup.  I should be able to do this for you if you want, but it is probably better for you to do so.  The `mix compile` can do the build with rebar.  The usage of mix for Erlang projects isn't meant to be well-documented due to pushing for rebar3 usage, however, it would be good to have a usable package.  Not sure if the current repository is forcing the usage of rebar3 instead of rebar2, but hopefully it doesn't matter.