### PR TITLE
rebar version 2 backwards compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,11 +13,6 @@
                    "src/msgpack_ext.erl"
                   ]}.
 
-{plugins, [
-    {rebar3_eqc, ".*", {git, "https://github.com/kellymclaughlin/rebar3-eqc-plugin.git", {tag, "0.0.8"}}},
-    rebar3_hex
-]}.
-
 %% {port_sources, ["c_src/*.c"]}.
 %% {port_env, [
 %% 	     %% Make sure to set -fPIC when compiling leveldb

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,10 @@
+case application:get_key(rebar, vsn) of
+  {ok, "3."++_} ->
+    PLUGINS = {plugins, [
+        {rebar3_eqc, ".*", {git, "https://github.com/kellymclaughlin/rebar3-eqc-plugin.git", {tag, "0.0.8"}}},
+        rebar3_hex
+    ]},
+    lists:keystore(plugins, 1, CONFIG, PLUGINS);
+  _ ->
+   CONFIG
+end.


### PR DESCRIPTION
I've added compatibility with existing applications that use rebar version 2 for compilation.

This update does not change the rebar3 compilation chain.