### PR TITLE
Allow Erlang/OTP 19.0 to compile.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "17|18"}.
+{require_otp_vsn, "17|18|19"}.
 
 {erl_opts, [fail_on_warning, debug_info, warn_untyped_record]}.
 %%, {parse_transform, eqc_cover}]}.


### PR DESCRIPTION
There doesn't appear to be any problems with using Erlang/OTP 19.0-rc1.