### PR TITLE
Allow Erlang/OTP 20.0 to compile.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,7 @@
-{require_otp_vsn, "17|18|19"}.
+%-*-Mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
+% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et nomod:
+
+{require_otp_vsn, "17|18|19|20"}.
 
 {erl_opts, [fail_on_warning, debug_info, warn_untyped_record]}.
 %%, {parse_transform, eqc_cover}]}.


### PR DESCRIPTION
The commit also adds modelines to the top of the rebar.config file, so that syntax highlighting and indentation is simpler.