### PR TITLE
Fix pack/unpack specs when using ext

### DIFF
--- a/src/msgpack.erl
+++ b/src/msgpack.erl
@@ -120,12 +120,14 @@ unpack(Bin, Opts) ->
 
 -spec unpack_stream(binary()) -> {msgpack:object(), binary()}
                                      | {error, incomplete}
-                                     | {error, {badarg, term()}}.
+                                     | {error, {badarg, term()}}
+                                     | {error, any()}.
 unpack_stream(Bin) -> unpack_stream(Bin, []).
 
 -spec unpack_stream(binary(), msgpack:options())->  {msgpack:object(), binary()}
                                                        | {error, incomplete}
-                                                       | {error, {badarg, term()}}.
+                                                       | {error, {badarg, term()}}
+                                                       | {error, any()}.
 unpack_stream(Bin, Opts0) when is_binary(Bin) ->
     Opts = parse_options(Opts0),
     try

--- a/src/msgpack_packer.erl
+++ b/src/msgpack_packer.erl
@@ -24,7 +24,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% pack them all
--spec pack(msgpack:object(), ?OPTION{}) -> binary().
+-spec pack(msgpack:object(), ?OPTION{}) -> binary() | {error, any()}.
 pack(I, _) when is_integer(I) andalso I < 0 ->
     pack_int(I);
 pack(I, _) when is_integer(I) ->
@@ -345,7 +345,7 @@ pack_map(M, Opt)->
             throw({badarg, M})
     end.
 
--spec pack_ext(any(), msgpack:ext_packer(), msgpack:options()) -> {ok, binary()} | {error, any()}.
+-spec pack_ext(any(), msgpack:ext_packer(), msgpack:options()) -> {ok, binary()}.
 pack_ext(Any, Packer, Opt) ->
     case Packer(Any, Opt) of
         {ok, {Type, Data}} when -16#80 =< Type andalso Type =< 16#7F ->

--- a/src/msgpack_packer.erl
+++ b/src/msgpack_packer.erl
@@ -24,7 +24,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% pack them all
--spec pack(msgpack:object(), ?OPTION{}) -> binary() | {error, any()}.
+-spec pack(msgpack:object(), ?OPTION{}) -> binary().
 pack(I, _) when is_integer(I) andalso I < 0 ->
     pack_int(I);
 pack(I, _) when is_integer(I) ->

--- a/src/msgpack_unpacker.erl
+++ b/src/msgpack_unpacker.erl
@@ -27,7 +27,7 @@
 -export([unpack_map/3, unpack_map_jiffy/3, unpack_map_jsx/3]).
 
 %% unpack them all
--spec unpack_stream(Bin::binary(), ?OPTION{}) -> {msgpack:object(), binary()} | no_return().
+-spec unpack_stream(Bin::binary(), ?OPTION{}) -> {msgpack:object(), binary()} | {error, any()} | no_return().
 %% ATOMS
 unpack_stream(<<16#C0, Rest/binary>>, _) ->
     {null, Rest};


### PR DESCRIPTION
When using external packers/unpackers, the results of some function can reflect the results of them, and the callback allows for `{error, any()}` results.